### PR TITLE
Remove Plugins Not Needed in Activator

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,3 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.1")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0")
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
-
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.2")


### PR DESCRIPTION
The Eclipse and IntelliJ plugins aren't needed when using Activator.  Having them causes an error:
http://typesafe.com/activator/template/akka-spray-websocket#comment-1330603034
