### PR TITLE
Add bintray dependency for scalaz-stream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version       := "0.4"
 
 scalaVersion  := "2.11.5"
 
+resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
+
 libraryDependencies ++= {
   val akkaV  = "2.3.9"
   val sprayV = "1.3.2"


### PR DESCRIPTION
* Error message was:

$ sbt
> compile
...
[warn]  [FAILED     ] org.scalaz.stream#scalaz-stream_2.11;0.5a!scalaz-stream_2.11.jar(bundle):  (0ms)
[warn] ==== local: tried
[warn]   /Users/peter_v/.ivy2/local/org.scalaz.stream/scalaz-stream_2.11/0.5a/bundles/scalaz-stream_2.11.jar
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/org/scalaz/stream/scalaz-stream_2.11/0.5a/scalaz-stream_2.11-0.5a.jar
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::              FAILED DOWNLOADS            ::
[warn]  :: ^ see resolution messages for details  ^ ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.scalaz.stream#scalaz-stream_2.11;0.5a!scalaz-stream_2.11.jar(bundle)
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[trace] Stack trace suppressed: run last *:update for the full output.
[error] (*:update) sbt.ResolveException: download failed: org.scalaz.stream#scalaz-stream_2.11;0.5a!scalaz-stream_2.11.jar(bundle)